### PR TITLE
Fix bug with autoplayed background video

### DIFF
--- a/src/app/video/video.component.html
+++ b/src/app/video/video.component.html
@@ -1,4 +1,4 @@
-<video playsinline autoplay muted loop poster="../../assets/images/orbitr-video-poster.png">
+<video playsinline autoplay [muted]="true" loop poster="../../assets/images/orbitr-video-poster.png">
   <!-- <source src="https://s3-us-west-1.amazonaws.com/orbitr-video/orbitr-web.ogv" type="video/ogg" />
   <source src="https://s3-us-west-1.amazonaws.com/orbitr-video/orbitr-web.mp4" type="video/mp4" />
   <source src="https://s3-us-west-1.amazonaws.com/orbitr-video/orbitr-web.webm" type="video/webm" /> -->


### PR DESCRIPTION
You are setting muted as a boolean attribute when the source of truth seems to be the prop (this may be an issue with angular). See 4.8.10.11 User interface at https://www.w3.org/TR/2011/WD-html5-20110113/video.html#dom-media-muted